### PR TITLE
docs: remove launchtube references

### DIFF
--- a/soroswap-api/README.md
+++ b/soroswap-api/README.md
@@ -9,7 +9,7 @@ The **Soroswap API** is built for developers and teams who want to integrate Sor
 * 🔁 **Fetch quotes and optimal routes** for token swaps across multiple protocols (Soroswap, Phoenix, Aqua and SDEX)
 * 📊 **Retrieve token and liquidity data**, including pool stats and available trading pairs
 * 🧾 **Build XDR transactions** for on-chain execution
-* 🚀 **(Limited-time)** Enable **gasless transactions** via LaunchTube integration
+* 🚀 **Submit signed transactions** directly via Soroban RPC or Horizon
 
 > 🔗 **Explore the full API reference here**:\
 > 👉 [https://api.soroswap.finance/docs](https://api.soroswap.finance/docs)

--- a/soroswap-api/beginner-example.html
+++ b/soroswap-api/beginner-example.html
@@ -439,8 +439,7 @@
 
                 // Send the signed transaction
                 const sendRequest = {
-                    xdr: appState.signedTransaction,    // The signed transaction
-                    launchtube: false                   // Use normal fees (not gasless)
+                    xdr: appState.signedTransaction     // The signed transaction
                 };
 
                 const sendResult = await makeAPIRequest('/send', sendRequest);

--- a/soroswap-api/beginner-guide.md
+++ b/soroswap-api/beginner-guide.md
@@ -195,8 +195,7 @@ async function sendTransaction() {
 
         // Send the signed transaction
         const sendRequest = {
-            xdr: appState.signedTransaction,    // The signed transaction
-            launchtube: false                   // Use normal fees (not gasless)
+            xdr: appState.signedTransaction     // The signed transaction
         };
 
         const sendResult = await makeAPIRequest('/send', sendRequest);

--- a/soroswap-api/quickstart.md
+++ b/soroswap-api/quickstart.md
@@ -120,10 +120,9 @@ class SoroswapClient {
     }
 
     // 3. Submit signed transaction
-    async sendTransaction(signedXdr, launchtube = false) {
+    async sendTransaction(signedXdr) {
         return this.apiRequest('/send', {
-            xdr: signedXdr,
-            launchtube
+            xdr: signedXdr
         });
     }
 }
@@ -165,12 +164,6 @@ async function executeSwap() {
 
 ## 📤 Advanced Options
 
-### Gasless Transactions
-```javascript
-// For users without XLM for fees
-const result = await client.sendTransaction(signedXdr, true);
-```
-
 ### Custom Transaction Submission
 ```javascript
 // Submit through your own infrastructure
@@ -206,8 +199,7 @@ const result = await server.submitTransaction(signedTransaction);
 #### Send Request
 ```javascript
 {
-    xdr: signedXdr,         // Signed transaction XDR
-    launchtube: false       // Set true for gasless transactions
+    xdr: signedXdr          // Signed transaction XDR
 }
 ```
 


### PR DESCRIPTION
## Summary
- Removed all LaunchTube references from Soroswap API documentation
- Updated send request examples to remove `launchtube` field
- Removed "gasless transactions" feature mention from README
- Updated quickstart, beginner guide, and beginner example HTML

## Context
LaunchTube integration is being removed from the Soroswap API. Transactions are now submitted directly via Soroban RPC or Horizon.

## Files changed
- `soroswap-api/README.md` — removed LaunchTube feature bullet
- `soroswap-api/quickstart.md` — removed launchtube param from sendTransaction(), removed gasless section, updated send request example
- `soroswap-api/beginner-guide.md` — removed launchtube from send request example
- `soroswap-api/beginner-example.html` — removed launchtube from send request example